### PR TITLE
Docker config selfadaptive

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+run-docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Define go base image and version
+FROM golang:1.20.3-alpine
+
+# Install g++ dependency (for plugin build)
+RUN apk --update add g++
+
+# Define GOROOT variable
+ENV GOROOT=/usr/local/go
+
+# Copy project files to container
+COPY . /go/selfadaptive
+
+# Change base path
+WORKDIR /go/selfadaptive

--- a/run-docker
+++ b/run-docker
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Creates docker image 
+# -t => [tag image] (name:tag)
+# . => context of build (current directory dot) 
+docker build -t selfadaptive:latest .
+
+# Executes docker container (The container is an instance of an image)
+# --rm => when stoped the container will be removed (but the container image remains)
+# -it => 'binds' iterative shell to container terminal
+docker run --rm -it selfadaptive:latest sh
+
+
+
+# Go Build Plugin
+# -buildmode=plugin
+

--- a/shared/shared.go
+++ b/shared/shared.go
@@ -51,8 +51,8 @@ const NumberOfColors = 7
 const ColorReset = "\033[0m"
 
 // Base Directories
-const SourcesDir = "/Volumes/GoogleDrive/Meu Drive/go/selfadaptive/example-plugin/envrnment/plugins/source"
-const ExecutablesDir = "/Volumes/GoogleDrive/Meu Drive/go/selfadaptive/example-plugin/envrnment/plugins/executable"
+const SourcesDir = "/go/selfadaptive/example-plugin/envrnment/plugins/source"
+const ExecutablesDir = "/go/selfadaptive/example-plugin/envrnment/plugins/executable"
 
 //const SourcesDir = "C:\\Users\\user\\go\\selfadaptive\\example-plugin\\envrnment\\sources"
 //const ExecutablesDir = "C:\\Users\\user\\go\\selfadaptive\\example-plugin\\envrnment\\executables"


### PR DESCRIPTION
Cria Dockerfile e executável 'run-docker' para criar e executar uma shell go com o projeto.

**Ao adicionar o container, tive que modificar o arquivo shared.go as propriedades do base paths dos plugins.**

De: 
https://github.com/gfads/selfadaptive/blob/4492e93c477acc03b97bdd3d716863d30c9f168f/shared/shared.go#L54-L55

Por:
```go
const SourcesDir = "/go/selfadaptive/example-plugin/envrnment/plugins/source"
const ExecutablesDir = "/go/selfadaptive/example-plugin/envrnment/plugins/executable"
```
